### PR TITLE
Fix payroll edit view syntax and adjust image upload imports

### DIFF
--- a/AI_ASSIST.md
+++ b/AI_ASSIST.md
@@ -1,0 +1,17 @@
+# AI Assist Progress
+
+## Summary
+- Ran `npm run check` to compile TypeScript.
+- Fixed syntax error in `payroll-edit-view.tsx` by removing an extra closing `<div>`.
+- Updated ImageUpload imports in `deduction-form.tsx` and `vacation-day-form.tsx` to use default export.
+
+## Remaining Issues
+- TypeScript compilation still reports numerous errors across components and pages.
+- Many API request calls use incorrect parameter order and need refactoring.
+- Data types for various fields (e.g., employee properties, document structures) require updates to match the shared schema.
+
+## Next Steps
+- Refactor API calls to match `apiRequest(method, url, data)` signature.
+- Resolve missing or mismatched properties in payroll and report components.
+- Add type definitions for server routes and shared schema to eliminate duplicates.
+- Re-run `npm run check` until the project compiles successfully.

--- a/HRPayMaster/client/src/components/payroll/deduction-form.tsx
+++ b/HRPayMaster/client/src/components/payroll/deduction-form.tsx
@@ -11,7 +11,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
-import { ImageUpload } from "@/components/ui/image-upload";
+import ImageUpload from "@/components/ui/image-upload";
 import { Minus, FileImage } from "lucide-react";
 
 const deductionFormSchema = z.object({

--- a/HRPayMaster/client/src/components/payroll/payroll-edit-view.tsx
+++ b/HRPayMaster/client/src/components/payroll/payroll-edit-view.tsx
@@ -574,6 +574,5 @@ function EmployeeEventForm({
         </Button>
       </div>
     </form>
-    </div>
   );
 }

--- a/HRPayMaster/client/src/components/vacation/vacation-day-form.tsx
+++ b/HRPayMaster/client/src/components/vacation/vacation-day-form.tsx
@@ -12,7 +12,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
-import { ImageUpload } from "@/components/ui/image-upload";
+import ImageUpload from "@/components/ui/image-upload";
 import { Calendar, AlertTriangle, FileImage } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 


### PR DESCRIPTION
## Summary
- remove stray closing div from payroll edit view component
- use default ImageUpload component import in deduction and vacation forms
- add AI_ASSIST progress document

## Testing
- `npm run check` *(fails: Argument of type '{ method: string; body: string; }' is not assignable to parameter of type 'string')*


------
https://chatgpt.com/codex/tasks/task_e_688f9873957c8323aabe663557c52f15