### PR TITLE
refactor apiRequest calls

### DIFF
--- a/HRPayMaster/client/src/components/payroll/deduction-form.tsx
+++ b/HRPayMaster/client/src/components/payroll/deduction-form.tsx
@@ -59,10 +59,8 @@ export function DeductionForm({
   const watchedDeductionType = form.watch("deductionType");
 
   const updatePayrollMutation = useMutation({
-    mutationFn: (data: any) => apiRequest(`/api/payroll/entries/${payrollEntryId}`, {
-      method: "PUT",
-      body: JSON.stringify(data),
-    }),
+    mutationFn: (data: any) =>
+      apiRequest("PUT", `/api/payroll/entries/${payrollEntryId}`, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/payroll"] });
       toast({
@@ -82,10 +80,7 @@ export function DeductionForm({
   });
 
   const createEmployeeEventMutation = useMutation({
-    mutationFn: (data: any) => apiRequest("/api/employee-events", {
-      method: "POST",
-      body: JSON.stringify(data),
-    }),
+    mutationFn: (data: any) => apiRequest("POST", "/api/employee-events", data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/employee-events"] });
     },

--- a/HRPayMaster/client/src/components/payroll/smart-deduction-form.tsx
+++ b/HRPayMaster/client/src/components/payroll/smart-deduction-form.tsx
@@ -49,10 +49,8 @@ export function SmartDeductionForm({
   });
 
   const updatePayrollMutation = useMutation({
-    mutationFn: (data: any) => apiRequest(`/api/payroll/entries/${payrollEntryId}`, {
-      method: "PUT",
-      body: JSON.stringify(data),
-    }),
+    mutationFn: (data: any) =>
+      apiRequest("PUT", `/api/payroll/entries/${payrollEntryId}`, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/payroll"] });
       toast({

--- a/HRPayMaster/client/src/components/payroll/smart-vacation-form.tsx
+++ b/HRPayMaster/client/src/components/payroll/smart-vacation-form.tsx
@@ -50,10 +50,8 @@ export function SmartVacationForm({
   });
 
   const updatePayrollMutation = useMutation({
-    mutationFn: (data: any) => apiRequest(`/api/payroll/entries/${payrollEntryId}`, {
-      method: "PUT",
-      body: JSON.stringify(data),
-    }),
+    mutationFn: (data: any) =>
+      apiRequest("PUT", `/api/payroll/entries/${payrollEntryId}`, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/payroll"] });
       toast({

--- a/HRPayMaster/client/src/components/vacation/vacation-day-form.tsx
+++ b/HRPayMaster/client/src/components/vacation/vacation-day-form.tsx
@@ -70,10 +70,8 @@ export function VacationDayForm({
   const watchedDays = form.watch("days");
 
   const updatePayrollMutation = useMutation({
-    mutationFn: (data: any) => apiRequest(`/api/payroll/entries/${payrollEntryId}`, {
-      method: "PUT",
-      body: JSON.stringify(data),
-    }),
+    mutationFn: (data: any) =>
+      apiRequest("PUT", `/api/payroll/entries/${payrollEntryId}`, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/payroll"] });
       toast({
@@ -93,10 +91,7 @@ export function VacationDayForm({
   });
 
   const createVacationRequestMutation = useMutation({
-    mutationFn: (data: any) => apiRequest("/api/vacations", {
-      method: "POST",
-      body: JSON.stringify(data),
-    }),
+    mutationFn: (data: any) => apiRequest("POST", "/api/vacations", data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/vacations"] });
     },
@@ -147,12 +142,9 @@ export function VacationDayForm({
 
       // Update sick leave balance if it's sick leave
       if (data.leaveType === "sick") {
-        await apiRequest(`/api/employees/${employeeId}/sick-leave-balance`, {
-          method: "POST",
-          body: JSON.stringify({
-            daysUsed: data.days,
-            year: new Date().getFullYear(),
-          }),
+        await apiRequest("POST", `/api/employees/${employeeId}/sick-leave-balance`, {
+          daysUsed: data.days,
+          year: new Date().getFullYear(),
         });
       }
 

--- a/HRPayMaster/client/src/pages/cars.tsx
+++ b/HRPayMaster/client/src/pages/cars.tsx
@@ -38,7 +38,7 @@ export default function Cars() {
   });
 
   const createCarMutation = useMutation({
-    mutationFn: (data: any) => apiRequest("/api/cars", "POST", data),
+    mutationFn: (data: any) => apiRequest("POST", "/api/cars", data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/cars"] });
       setIsCreateCarDialogOpen(false);
@@ -50,7 +50,7 @@ export default function Cars() {
   });
 
   const assignCarMutation = useMutation({
-    mutationFn: (data: any) => apiRequest("/api/car-assignments", "POST", data),
+    mutationFn: (data: any) => apiRequest("POST", "/api/car-assignments", data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/cars"] });
       queryClient.invalidateQueries({ queryKey: ["/api/car-assignments"] });
@@ -63,8 +63,8 @@ export default function Cars() {
   });
 
   const updateAssignmentMutation = useMutation({
-    mutationFn: ({ id, data }: { id: string; data: any }) => 
-      apiRequest(`/api/car-assignments/${id}`, "PUT", data),
+    mutationFn: ({ id, data }: { id: string; data: any }) =>
+      apiRequest("PUT", `/api/car-assignments/${id}`, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/cars"] });
       queryClient.invalidateQueries({ queryKey: ["/api/car-assignments"] });
@@ -76,7 +76,7 @@ export default function Cars() {
   });
 
   const deleteCarMutation = useMutation({
-    mutationFn: (id: string) => apiRequest(`/api/cars/${id}`, "DELETE"),
+    mutationFn: (id: string) => apiRequest("DELETE", `/api/cars/${id}`),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/cars"] });
       toast({ title: "Car deleted successfully" });

--- a/HRPayMaster/client/src/pages/loans.tsx
+++ b/HRPayMaster/client/src/pages/loans.tsx
@@ -32,7 +32,7 @@ export default function Loans() {
   });
 
   const createMutation = useMutation({
-    mutationFn: (data: any) => apiRequest("/api/loans", "POST", data),
+    mutationFn: (data: any) => apiRequest("POST", "/api/loans", data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/loans"] });
       setIsCreateDialogOpen(false);
@@ -44,8 +44,8 @@ export default function Loans() {
   });
 
   const updateMutation = useMutation({
-    mutationFn: ({ id, data }: { id: string; data: any }) => 
-      apiRequest(`/api/loans/${id}`, "PUT", data),
+    mutationFn: ({ id, data }: { id: string; data: any }) =>
+      apiRequest("PUT", `/api/loans/${id}`, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/loans"] });
       toast({ title: "Loan updated successfully" });
@@ -56,7 +56,7 @@ export default function Loans() {
   });
 
   const deleteMutation = useMutation({
-    mutationFn: (id: string) => apiRequest(`/api/loans/${id}`, "DELETE"),
+    mutationFn: (id: string) => apiRequest("DELETE", `/api/loans/${id}`),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/loans"] });
       toast({ title: "Loan deleted successfully" });

--- a/HRPayMaster/client/src/pages/vacations.tsx
+++ b/HRPayMaster/client/src/pages/vacations.tsx
@@ -32,7 +32,7 @@ export default function Vacations() {
   });
 
   const createMutation = useMutation({
-    mutationFn: (data: any) => apiRequest("/api/vacations", "POST", data),
+    mutationFn: (data: any) => apiRequest("POST", "/api/vacations", data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/vacations"] });
       setIsCreateDialogOpen(false);
@@ -44,8 +44,8 @@ export default function Vacations() {
   });
 
   const updateMutation = useMutation({
-    mutationFn: ({ id, data }: { id: string; data: any }) => 
-      apiRequest(`/api/vacations/${id}`, "PUT", data),
+    mutationFn: ({ id, data }: { id: string; data: any }) =>
+      apiRequest("PUT", `/api/vacations/${id}`, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/vacations"] });
       toast({ title: "Vacation request updated successfully" });
@@ -56,7 +56,7 @@ export default function Vacations() {
   });
 
   const deleteMutation = useMutation({
-    mutationFn: (id: string) => apiRequest(`/api/vacations/${id}`, "DELETE"),
+    mutationFn: (id: string) => apiRequest("DELETE", `/api/vacations/${id}`),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/vacations"] });
       toast({ title: "Vacation request deleted successfully" });


### PR DESCRIPTION
## Summary
- fix apiRequest usage ordering and remove custom fetch options across car, vacation, loan, and payroll forms
- clean up vacation day form API calls

## Testing
- `npm run check` (fails: Property 'employee' does not exist on type etc.)


------
https://chatgpt.com/codex/tasks/task_e_688fb775d7a48323aa2b186c3fa14d88