### PR TITLE
Add role field to employees

### DIFF
--- a/HRPayMaster/client/src/components/employees/employee-form.tsx
+++ b/HRPayMaster/client/src/components/employees/employee-form.tsx
@@ -41,6 +41,7 @@ export default function EmployeeForm({
       email: initialData?.email || "",
       phone: initialData?.phone || "",
       position: initialData?.position || "",
+      role: initialData?.role || "employee",
       departmentId: initialData?.departmentId || undefined,
       salary: initialData?.salary || "",
       startDate: initialData?.startDate || new Date().toISOString().split('T')[0],
@@ -219,6 +220,28 @@ export default function EmployeeForm({
                     <SelectItem value="active">Active</SelectItem>
                     <SelectItem value="inactive">Inactive</SelectItem>
                     <SelectItem value="on_leave">On Leave</SelectItem>
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="role"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Role</FormLabel>
+                <Select onValueChange={field.onChange} value={field.value || "employee"}>
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select Role" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="employee">Employee</SelectItem>
+                    <SelectItem value="admin">Admin</SelectItem>
                   </SelectContent>
                 </Select>
                 <FormMessage />

--- a/HRPayMaster/migrations/0001_add_role_to_employees.sql
+++ b/HRPayMaster/migrations/0001_add_role_to_employees.sql
@@ -1,0 +1,2 @@
+ALTER TABLE employees ADD COLUMN IF NOT EXISTS role text DEFAULT 'employee' NOT NULL;
+UPDATE employees SET role = 'employee' WHERE role IS NULL;

--- a/HRPayMaster/server/routes.ts
+++ b/HRPayMaster/server/routes.ts
@@ -111,7 +111,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.post("/api/employees", async (req, res) => {
     try {
       const employee = insertEmployeeSchema.parse(req.body);
-      const newEmployee = await storage.createEmployee(employee);
+      const newEmployee = await storage.createEmployee({
+        ...employee,
+        role: employee.role || "employee",
+      });
       res.status(201).json(newEmployee);
     } catch (error) {
       if (error instanceof z.ZodError) {

--- a/HRPayMaster/server/storage.ts
+++ b/HRPayMaster/server/storage.ts
@@ -188,6 +188,7 @@ export class DatabaseStorage implements IStorage {
       .insert(employees)
       .values({
         ...employee,
+        role: employee.role || "employee",
         status: employee.status || "active",
         visaAlertDays: employee.visaAlertDays || 30,
         civilIdAlertDays: employee.civilIdAlertDays || 60,

--- a/HRPayMaster/shared/schema.ts
+++ b/HRPayMaster/shared/schema.ts
@@ -17,6 +17,7 @@ export const employees = pgTable("employees", {
   email: text("email"),
   phone: text("phone"),
   position: text("position").notNull(),
+  role: text("role").notNull().default("employee"),
   departmentId: varchar("department_id").references(() => departments.id),
   salary: numeric("salary", { precision: 10, scale: 2 }).notNull(),
   workLocation: varchar("work_location", { length: 100 }).default("Office").notNull(),


### PR DESCRIPTION
## Summary
- add non-null role column to employees table and expose via API
- support role selection in employee form
- add migration to backfill employee roles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: Property 'employee' does not exist on type ... and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_688fe771ad348323b67c8177f300417f