### PR TITLE
feat: add employee report endpoint

### DIFF
--- a/HRPayMaster/server/routes.ts
+++ b/HRPayMaster/server/routes.ts
@@ -956,6 +956,82 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // Employee report route
+  app.get("/api/reports/employees/:id", async (req, res) => {
+    const querySchema = z.object({
+      startDate: z
+        .string()
+        .refine((d) => !isNaN(Date.parse(d)), { message: "Invalid startDate" }),
+      endDate: z
+        .string()
+        .refine((d) => !isNaN(Date.parse(d)), { message: "Invalid endDate" }),
+      groupBy: z.enum(["month", "year"]).optional().default("month"),
+    });
+
+    try {
+      const { startDate, endDate, groupBy } = querySchema.parse(req.query);
+      const report = await storage.getEmployeeReport(req.params.id, {
+        startDate,
+        endDate,
+        groupBy,
+      });
+
+      const response = report.map((period) => {
+        const bonuses =
+          period.payrollEntries.reduce(
+            (sum, e) => sum + Number(e.bonusAmount || 0),
+            0
+          ) +
+          period.employeeEvents
+            .filter((e) => e.eventType === "bonus")
+            .reduce((s, e) => s + Number(e.amount || 0), 0);
+
+        const deductions =
+          period.payrollEntries.reduce(
+            (sum, e) =>
+              sum +
+              Number(e.taxDeduction || 0) +
+              Number(e.socialSecurityDeduction || 0) +
+              Number(e.healthInsuranceDeduction || 0) +
+              Number(e.loanDeduction || 0) +
+              Number(e.otherDeductions || 0),
+            0
+          ) +
+          period.employeeEvents
+            .filter((e) => e.eventType === "deduction" || e.eventType === "penalty")
+            .reduce((s, e) => s + Number(e.amount || 0), 0) +
+          period.loans.reduce((s, l) => s + Number(l.monthlyDeduction || 0), 0);
+
+        const netPay = period.payrollEntries.reduce(
+          (sum, e) => sum + Number(e.netPay || 0),
+          0
+        );
+
+        return {
+          period: period.period,
+          totals: {
+            bonuses,
+            deductions,
+            netPay,
+          },
+          payrollEntries: period.payrollEntries,
+          employeeEvents: period.employeeEvents,
+          loans: period.loans,
+          vacationRequests: period.vacationRequests,
+        };
+      });
+
+      res.json(response);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res
+          .status(400)
+          .json({ message: "Invalid query parameters", errors: error.errors });
+      }
+      res.status(500).json({ message: "Failed to fetch employee report" });
+    }
+  });
+
   // Payroll entry routes
   app.put("/api/payroll/entries/:id", async (req, res) => {
     try {


### PR DESCRIPTION
## Summary
- extend storage interface and database implementation to build employee payroll reports grouped by month or year
- add API route `/api/reports/employees/:id` with query validation and aggregated totals

## Testing
- `npm run check` *(fails: Property 'employee' does not exist on type ...)*

------
https://chatgpt.com/codex/tasks/task_e_6890ad1a9a508323b92484e4ae41e5b3