### PR TITLE
Refactor image upload handlers in deduction and vacation forms

### DIFF
--- a/HRPayMaster/client/src/components/payroll/deduction-form.tsx
+++ b/HRPayMaster/client/src/components/payroll/deduction-form.tsx
@@ -240,12 +240,12 @@ export function DeductionForm({
                   </FormLabel>
                   <div className="space-y-2">
                     <ImageUpload
-                      onImageUpload={(base64) => {
-                        setUploadedImage(base64);
+                      onChange={(base64) => {
+                        setUploadedImage(base64 || "");
                         field.onChange(base64);
                       }}
-                      currentImage={uploadedImage}
-                      placeholder="Upload receipt, penalty notice, etc."
+                      value={uploadedImage || undefined}
+                      label="Upload receipt, penalty notice, etc."
                     />
                     {watchedDeductionType === "penalty" && (
                       <p className="text-xs text-muted-foreground">

--- a/HRPayMaster/client/src/components/vacation/vacation-day-form.tsx
+++ b/HRPayMaster/client/src/components/vacation/vacation-day-form.tsx
@@ -289,12 +289,12 @@ export function VacationDayForm({
                   </FormLabel>
                   <div className="space-y-2">
                     <ImageUpload
-                      onImageUpload={(base64) => {
-                        setUploadedImage(base64);
+                      onChange={(base64) => {
+                        setUploadedImage(base64 || "");
                         field.onChange(base64);
                       }}
-                      currentImage={uploadedImage}
-                      placeholder="Upload medical certificate, emergency documentation, etc."
+                      value={uploadedImage || undefined}
+                      label="Upload medical certificate, emergency documentation, etc."
                     />
                     {watchedLeaveType === "sick" && (
                       <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
- align ImageUpload props with updated API in deduction and vacation forms
- propagate base64 values via onChange and local state

## Testing
- `npm run check` *(fails: Property 'employee' does not exist on type...)*

------
https://chatgpt.com/codex/tasks/task_e_6890de064a1c8323afd72de54f78185d