### PR TITLE
Wrap health icon in span for tooltip

### DIFF
--- a/HRPayMaster/client/src/components/payroll/enhanced-payroll-table.tsx
+++ b/HRPayMaster/client/src/components/payroll/enhanced-payroll-table.tsx
@@ -356,7 +356,9 @@ export function EnhancedPayrollTable({ entries, payrollId }: EnhancedPayrollTabl
                   <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
                     <div className="flex items-center space-x-2">
                       <span>{formatCurrency(calculateRowTotal(entry))}</span>
-                      <HealthIcon className={`h-4 w-4 ${healthIndicator.color}`} title={healthIndicator.label} />
+                      <span title={healthIndicator.label}>
+                        <HealthIcon className={`h-4 w-4 ${healthIndicator.color}`} />
+                      </span>
                     </div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">


### PR DESCRIPTION
## Summary
- wrap payroll table health icon with span that supplies title tooltip

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Property 'employee' does not exist...)*

------
https://chatgpt.com/codex/tasks/task_e_6890e0161db8832382232bc2e5e94f6f