### PR TITLE
docs: add Neon database setup instructions

### DIFF
--- a/HRPayMaster/.gitignore
+++ b/HRPayMaster/.gitignore
@@ -4,3 +4,4 @@ dist
 server/public
 vite.config.ts.*
 *.tar.gz
+.env

--- a/HRPayMaster/README.md
+++ b/HRPayMaster/README.md
@@ -1,0 +1,26 @@
+# HRPayMaster
+
+## Neon Database Setup
+
+1. **Get a connection string**
+   - Sign in to the [Neon](https://neon.tech) dashboard and copy the connection string for your project.
+2. **Configure environment variables**
+   - Create a `.env` file in this directory or add secrets via your hosting platform's UI.
+   - Define the following variables:
+
+     ```bash
+     DATABASE_URL="<your Neon connection string>"
+     SESSION_SECRET="<random session secret>"
+     ```
+
+3. **Install dependencies and push the database schema**
+
+   ```bash
+   npm install
+   npm run db:push
+   ```
+
+4. **Start the application**
+   - Development: `npm run dev`
+   - Production: `npm run build` followed by `npm run start`
+


### PR DESCRIPTION
## Summary
- document Neon database setup with environment variables and startup commands
- ignore local `.env` file

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a03bf6bb848323aedb47c61594c7d8