### PR TITLE
Add database connection string to env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DATABASE_URL='postgresql://neondb_owner:npg_L93gxFlJSDnq@ep-soft-math-a7ixv82u-pooler.ap-southeast-2.aws.neon.tech/neondb?sslmode=require&channel_binding=require'


### PR DESCRIPTION
## Summary
- add DATABASE_URL to root .env file for Neon database connection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a03e62f8488323a99fd1881af91a67