### PR TITLE
refactor: use shared currency and date formatters

### DIFF
--- a/HRPayMaster/client/src/components/employees/employee-table.tsx
+++ b/HRPayMaster/client/src/components/employees/employee-table.tsx
@@ -21,6 +21,7 @@ import {
   ChevronUp,
 } from "lucide-react";
 import type { EmployeeWithDepartment, Department } from "@shared/schema";
+import { formatCurrency, formatDate } from "@/lib/utils";
 
 interface EmployeesResponse {
   data: EmployeeWithDepartment[];
@@ -97,13 +98,6 @@ export default function EmployeeTable({
   const employees: EmployeeWithDepartment[] = data?.data ?? [];
   const totalPages = Math.max(1, Math.ceil((data?.total ?? 0) / pageSize));
 
-  const formatCurrency = (amount: string) => {
-    const num = parseFloat(amount);
-    return new Intl.NumberFormat('en-KW', {
-      style: 'currency',
-      currency: 'KWD',
-    }).format(num);
-  };
 
   const getStatusColor = (status: string) => {
     switch (status) {

--- a/HRPayMaster/client/src/components/payroll/payroll-details-view.tsx
+++ b/HRPayMaster/client/src/components/payroll/payroll-details-view.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { DollarSign, User, Calendar, FileText } from "lucide-react";
 import type { PayrollRunWithEntries } from "@shared/schema";
+import { formatCurrency, formatDate } from "@/lib/utils";
 
 interface PayrollDetailsViewProps {
   payrollId: string;
@@ -14,23 +15,6 @@ export default function PayrollDetailsView({ payrollId }: PayrollDetailsViewProp
     queryKey: ["/api/payroll", payrollId],
   });
 
-  const formatCurrency = (amount: number | string) => {
-    const num = typeof amount === 'string' ? parseFloat(amount) : amount;
-    return new Intl.NumberFormat('en-KW', {
-      style: 'currency',
-      currency: 'KWD',
-      minimumFractionDigits: 3,
-      maximumFractionDigits: 3,
-    }).format(num);
-  };
-
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      month: 'long',
-      day: 'numeric',
-      year: 'numeric'
-    });
-  };
 
   const getStatusColor = (status: string) => {
     switch (status) {

--- a/HRPayMaster/client/src/components/payroll/payroll-edit-view.tsx
+++ b/HRPayMaster/client/src/components/payroll/payroll-edit-view.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
+import { formatCurrency, formatDate } from "@/lib/utils";
 import type { PayrollRunWithEntries, PayrollEntry, InsertEmployeeEvent } from "@shared/schema";
 import { VacationDayForm } from "@/components/vacation/vacation-day-form";
 import { DeductionForm } from "@/components/payroll/deduction-form";
@@ -114,23 +115,6 @@ export default function PayrollEditView({ payrollId }: PayrollEditViewProps) {
     },
   });
 
-  const formatCurrency = (amount: number | string) => {
-    const num = typeof amount === 'string' ? parseFloat(amount) : amount;
-    return new Intl.NumberFormat('en-KW', {
-      style: 'currency',
-      currency: 'KWD',
-      minimumFractionDigits: 3,
-      maximumFractionDigits: 3,
-    }).format(num);
-  };
-
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      month: 'long',
-      day: 'numeric',
-      year: 'numeric'
-    });
-  };
 
   const handleCellEdit = (entryId: string, field: string, value: string) => {
     const cellKey = `${entryId}-${field}`;

--- a/HRPayMaster/client/src/components/payroll/payroll-summary.tsx
+++ b/HRPayMaster/client/src/components/payroll/payroll-summary.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Calendar, Users, Calculator, TrendingDown, TrendingUp, AlertCircle } from "lucide-react";
+import { formatCurrency, formatDate } from "@/lib/utils";
 
 interface PayrollEntry {
   id: string;
@@ -37,13 +38,6 @@ export default function PayrollSummary({
   totalNet, 
   totalDeductions 
 }: PayrollSummaryProps) {
-  const formatCurrency = (amount: number | string) => {
-    const num = typeof amount === 'string' ? parseFloat(amount) : amount;
-    return new Intl.NumberFormat('en-KW', {
-      style: 'currency',
-      currency: 'KWD',
-    }).format(num);
-  };
 
   const employeesWithAdjustments = entries.filter(entry => 
     entry.adjustmentReason || entry.vacationDays > 0 || parseFloat(entry.loanDeduction) > 0

--- a/HRPayMaster/client/src/pages/dashboard.tsx
+++ b/HRPayMaster/client/src/pages/dashboard.tsx
@@ -2,11 +2,11 @@ import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { 
-  Users, 
-  DollarSign, 
-  Building, 
-  Clock, 
+import {
+  Users,
+  DollarSign,
+  Building,
+  Clock,
   Plus,
   ArrowRight,
   User,
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { Link } from "wouter";
 import type { EmployeeWithDepartment, PayrollRun } from "@shared/schema";
+import { formatCurrency, formatDate } from "@/lib/utils";
 
 interface DashboardStats {
   totalEmployees: number;
@@ -39,21 +40,6 @@ export default function Dashboard() {
   const recentPayrolls = payrollRuns?.slice(0, 3) || [];
   const latestPayroll = payrollRuns?.[0];
 
-  const formatCurrency = (amount: number | string) => {
-    const num = typeof amount === 'string' ? parseFloat(amount) : amount;
-    return new Intl.NumberFormat('en-KW', {
-      style: 'currency',
-      currency: 'KWD',
-    }).format(num);
-  };
-
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric'
-    });
-  };
 
   if (statsLoading || employeesLoading || payrollLoading) {
     return (

--- a/HRPayMaster/client/src/pages/employee-events.tsx
+++ b/HRPayMaster/client/src/pages/employee-events.tsx
@@ -14,7 +14,7 @@ import { Plus, Calendar as CalendarIcon, TrendingUp, TrendingDown, Award, AlertT
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { format } from "date-fns";
-import { cn } from "@/lib/utils";
+import { cn, formatCurrency, formatDate } from "@/lib/utils";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import type { EmployeeEvent, Employee, InsertEmployeeEvent } from "@shared/schema";
@@ -88,21 +88,6 @@ export default function EmployeeEvents() {
     },
   });
 
-  const formatCurrency = (amount: number | string) => {
-    const num = typeof amount === 'string' ? parseFloat(amount) : amount;
-    return new Intl.NumberFormat('en-KW', {
-      style: 'currency',
-      currency: 'KWD',
-    }).format(num);
-  };
-
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric'
-    });
-  };
 
   const getEventTypeIcon = (eventType: string) => {
     switch (eventType) {

--- a/HRPayMaster/client/src/pages/payroll.tsx
+++ b/HRPayMaster/client/src/pages/payroll.tsx
@@ -11,6 +11,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Calculator, DollarSign, FileText, Trash2, Eye, Edit } from "lucide-react";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
+import { formatCurrency, formatDate } from "@/lib/utils";
 import type { PayrollRun } from "@shared/schema";
 
 interface PayrollGenerateRequest {
@@ -73,21 +74,6 @@ export default function Payroll() {
     },
   });
 
-  const formatCurrency = (amount: number | string) => {
-    const num = typeof amount === 'string' ? parseFloat(amount) : amount;
-    return new Intl.NumberFormat('en-KW', {
-      style: 'currency',
-      currency: 'KWD',
-    }).format(num);
-  };
-
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric'
-    });
-  };
 
   const handleGeneratePayroll = (data: PayrollGenerateRequest) => {
     generatePayrollMutation.mutate(data);


### PR DESCRIPTION
## Summary
- replace page and component currency/date helpers with shared utilities
- import `formatCurrency` and `formatDate` from `@/lib/utils`

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a044f97338832397f966183139d100