### PR TITLE
Add tests for loans, cars, and payroll pages

### DIFF
--- a/HRPayMaster/client/src/pages/cars.test.tsx
+++ b/HRPayMaster/client/src/pages/cars.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from '@/lib/queryClient';
+import Cars from './cars';
+import '@testing-library/jest-dom';
+
+const toast = vi.fn();
+const mutationMocks: any[] = [];
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual: any = await vi.importActual('@tanstack/react-query');
+  return {
+    ...actual,
+    useMutation: (options: any) => {
+      const mock = {
+        shouldError: false,
+        isPending: false,
+        mutate: (vars: any) => {
+          if (mock.shouldError) {
+            options.onError?.('error', vars, null);
+          } else {
+            options.onSuccess?.('success', vars, null);
+          }
+        }
+      };
+      mutationMocks.push(mock);
+      return mock;
+    }
+  };
+});
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast }),
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}));
+
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children }: any) => <div>{children}</div>,
+  CardContent: ({ children }: any) => <div>{children}</div>,
+  CardDescription: ({ children }: any) => <div>{children}</div>,
+  CardHeader: ({ children }: any) => <div>{children}</div>,
+  CardTitle: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children }: any) => <div>{children}</div>,
+  DialogContent: ({ children }: any) => <div>{children}</div>,
+  DialogDescription: ({ children }: any) => <div>{children}</div>,
+  DialogFooter: ({ children }: any) => <div>{children}</div>,
+  DialogHeader: ({ children }: any) => <div>{children}</div>,
+  DialogTitle: ({ children }: any) => <div>{children}</div>,
+  DialogTrigger: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/form', () => ({
+  Form: ({ children }: any) => <div>{children}</div>,
+  FormControl: ({ children }: any) => <div>{children}</div>,
+  FormField: ({ render }: any) => render({ field: { onChange: vi.fn(), value: '' } }),
+  FormItem: ({ children }: any) => <div>{children}</div>,
+  FormLabel: ({ children }: any) => <label>{children}</label>,
+  FormMessage: () => <div />,
+}));
+
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: any) => <input {...props} />,
+}));
+
+vi.mock('@/components/ui/select', () => ({
+  Select: ({ children }: any) => <div>{children}</div>,
+  SelectContent: ({ children }: any) => <div>{children}</div>,
+  SelectItem: ({ children, value }: any) => <div data-value={value}>{children}</div>,
+  SelectTrigger: ({ children }: any) => <div>{children}</div>,
+  SelectValue: ({ placeholder }: any) => <span>{placeholder}</span>,
+}));
+
+vi.mock('@/components/ui/textarea', () => ({
+  Textarea: (props: any) => <textarea {...props} />,
+}));
+
+vi.mock('@/components/ui/badge', () => ({
+  Badge: ({ children }: any) => <span>{children}</span>,
+}));
+
+vi.mock('@/components/ui/tabs', () => ({
+  Tabs: ({ children }: any) => <div>{children}</div>,
+  TabsContent: ({ children }: any) => <div>{children}</div>,
+  TabsList: ({ children }: any) => <div>{children}</div>,
+  TabsTrigger: ({ children }: any) => <div>{children}</div>,
+}));
+
+beforeEach(() => {
+  queryClient.clear();
+  toast.mockReset();
+  mutationMocks.length = 0;
+});
+
+describe('Cars page', () => {
+  it('renders cars and handles mutations with error handling', () => {
+    const cars = [
+      {
+        id: '1',
+        make: 'Toyota',
+        model: 'Corolla',
+        year: '2024',
+        plateNumber: 'ABC123',
+        status: 'available',
+        mileage: 1000,
+        currentAssignment: null,
+      },
+    ];
+    queryClient.setQueryData(['/api/cars'], cars);
+    queryClient.setQueryData(['/api/car-assignments'], []);
+    queryClient.setQueryData(['/api/employees'], []);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Cars />
+      </QueryClientProvider>
+    );
+
+    expect(screen.getByText('2024 Toyota Corolla')).toBeInTheDocument();
+
+    // create car success
+    mutationMocks[0].mutate({});
+    expect(toast).toHaveBeenCalledWith({ title: 'Car added successfully' });
+    toast.mockReset();
+    // create car error
+    mutationMocks[0].shouldError = true;
+    mutationMocks[0].mutate({});
+    expect(toast).toHaveBeenCalledWith({ title: 'Failed to add car', variant: 'destructive' });
+    mutationMocks[0].shouldError = false;
+    toast.mockReset();
+
+    // assign car success
+    mutationMocks[1].mutate({});
+    expect(toast).toHaveBeenCalledWith({ title: 'Car assigned successfully' });
+    toast.mockReset();
+    // assign car error
+    mutationMocks[1].shouldError = true;
+    mutationMocks[1].mutate({});
+    expect(toast).toHaveBeenCalledWith({ title: 'Failed to assign car', variant: 'destructive' });
+    mutationMocks[1].shouldError = false;
+    toast.mockReset();
+
+    // update assignment success
+    mutationMocks[2].mutate({});
+    expect(toast).toHaveBeenCalledWith({ title: 'Assignment updated successfully' });
+    toast.mockReset();
+    // update assignment error
+    mutationMocks[2].shouldError = true;
+    mutationMocks[2].mutate({});
+    expect(toast).toHaveBeenCalledWith({ title: 'Failed to update assignment', variant: 'destructive' });
+    mutationMocks[2].shouldError = false;
+    toast.mockReset();
+
+    // delete car success
+    mutationMocks[3].mutate('1');
+    expect(toast).toHaveBeenCalledWith({ title: 'Car deleted successfully' });
+    toast.mockReset();
+    // delete car error
+    mutationMocks[3].shouldError = true;
+    mutationMocks[3].mutate('1');
+    expect(toast).toHaveBeenCalledWith({ title: 'Failed to delete car', variant: 'destructive' });
+  });
+});
+

--- a/HRPayMaster/client/src/pages/loans.test.tsx
+++ b/HRPayMaster/client/src/pages/loans.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from '@/lib/queryClient';
+import Loans from './loans';
+import '@testing-library/jest-dom';
+
+const toast = vi.fn();
+const mutationMocks: any[] = [];
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual: any = await vi.importActual('@tanstack/react-query');
+  return {
+    ...actual,
+    useMutation: (options: any) => {
+      const mock = {
+        shouldError: false,
+        isPending: false,
+        mutate: (vars: any) => {
+          if (mock.shouldError) {
+            options.onError?.('error', vars, null);
+          } else {
+            options.onSuccess?.('success', vars, null);
+          }
+        }
+      };
+      mutationMocks.push(mock);
+      return mock;
+    }
+  };
+});
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast }),
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}));
+
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children }: any) => <div>{children}</div>,
+  CardContent: ({ children }: any) => <div>{children}</div>,
+  CardDescription: ({ children }: any) => <div>{children}</div>,
+  CardHeader: ({ children }: any) => <div>{children}</div>,
+  CardTitle: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children }: any) => <div>{children}</div>,
+  DialogContent: ({ children }: any) => <div>{children}</div>,
+  DialogDescription: ({ children }: any) => <div>{children}</div>,
+  DialogFooter: ({ children }: any) => <div>{children}</div>,
+  DialogHeader: ({ children }: any) => <div>{children}</div>,
+  DialogTitle: ({ children }: any) => <div>{children}</div>,
+  DialogTrigger: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/form', () => ({
+  Form: ({ children }: any) => <div>{children}</div>,
+  FormControl: ({ children }: any) => <div>{children}</div>,
+  FormField: ({ render }: any) => render({ field: { onChange: vi.fn(), value: '' } }),
+  FormItem: ({ children }: any) => <div>{children}</div>,
+  FormLabel: ({ children }: any) => <label>{children}</label>,
+  FormMessage: () => <div />,
+}));
+
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: any) => <input {...props} />,
+}));
+
+vi.mock('@/components/ui/select', () => ({
+  Select: ({ children }: any) => <div>{children}</div>,
+  SelectContent: ({ children }: any) => <div>{children}</div>,
+  SelectItem: ({ children, value }: any) => <div data-value={value}>{children}</div>,
+  SelectTrigger: ({ children }: any) => <div>{children}</div>,
+  SelectValue: ({ placeholder }: any) => <span>{placeholder}</span>,
+}));
+
+vi.mock('@/components/ui/textarea', () => ({
+  Textarea: (props: any) => <textarea {...props} />,
+}));
+
+vi.mock('@/components/ui/badge', () => ({
+  Badge: ({ children }: any) => <span>{children}</span>,
+}));
+
+beforeEach(() => {
+  queryClient.clear();
+  toast.mockReset();
+  mutationMocks.length = 0;
+});
+
+describe('Loans page', () => {
+  it('renders loans and handles create/update/delete with error handling', () => {
+    const loans = [
+      {
+        id: '1',
+        employee: { firstName: 'Alice', lastName: 'Smith' },
+        amount: '100',
+        monthlyDeduction: '10',
+        startDate: '2024-01-01',
+        status: 'pending',
+        interestRate: '0',
+        reason: '',
+      },
+    ];
+    queryClient.setQueryData(['/api/loans'], loans);
+    queryClient.setQueryData(['/api/employees'], []);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Loans />
+      </QueryClientProvider>
+    );
+
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+
+    // create success
+    mutationMocks[0].mutate({});
+    expect(toast).toHaveBeenCalledWith({ title: 'Loan created successfully' });
+    toast.mockReset();
+    // create error
+    mutationMocks[0].shouldError = true;
+    mutationMocks[0].mutate({});
+    expect(toast).toHaveBeenCalledWith({ title: 'Failed to create loan', variant: 'destructive' });
+    mutationMocks[0].shouldError = false;
+    toast.mockReset();
+
+    // update success
+    mutationMocks[1].mutate({});
+    expect(toast).toHaveBeenCalledWith({ title: 'Loan updated successfully' });
+    toast.mockReset();
+    // update error
+    mutationMocks[1].shouldError = true;
+    mutationMocks[1].mutate({});
+    expect(toast).toHaveBeenCalledWith({ title: 'Failed to update loan', variant: 'destructive' });
+    mutationMocks[1].shouldError = false;
+    toast.mockReset();
+
+    // delete success
+    mutationMocks[2].mutate('1');
+    expect(toast).toHaveBeenCalledWith({ title: 'Loan deleted successfully' });
+    toast.mockReset();
+    // delete error
+    mutationMocks[2].shouldError = true;
+    mutationMocks[2].mutate('1');
+    expect(toast).toHaveBeenCalledWith({ title: 'Failed to delete loan', variant: 'destructive' });
+  });
+});
+

--- a/HRPayMaster/client/src/pages/payroll.test.tsx
+++ b/HRPayMaster/client/src/pages/payroll.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from '@/lib/queryClient';
+import Payroll from './payroll';
+import '@testing-library/jest-dom';
+
+const toast = vi.fn();
+const mutationMocks: any[] = [];
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual: any = await vi.importActual('@tanstack/react-query');
+  return {
+    ...actual,
+    useMutation: (options: any) => {
+      const mock = {
+        shouldError: false,
+        isPending: false,
+        mutate: (vars: any) => {
+          if (mock.shouldError) {
+            options.onError?.('error', vars, null);
+          } else {
+            options.onSuccess?.('success', vars, null);
+          }
+        }
+      };
+      mutationMocks.push(mock);
+      return mock;
+    }
+  };
+});
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast }),
+}));
+
+vi.mock('@/components/payroll/payroll-form', () => ({
+  default: () => <div>PayrollForm</div>,
+}));
+
+vi.mock('@/components/payroll/payroll-details-view', () => ({
+  default: () => <div>PayrollDetailsView</div>,
+}));
+
+vi.mock('@/components/payroll/payroll-edit-view-simple', () => ({
+  default: () => <div>PayrollEditView</div>,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}));
+
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children }: any) => <div>{children}</div>,
+  CardContent: ({ children }: any) => <div>{children}</div>,
+  CardHeader: ({ children }: any) => <div>{children}</div>,
+  CardTitle: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/badge', () => ({
+  Badge: ({ children }: any) => <span>{children}</span>,
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children }: any) => <div>{children}</div>,
+  DialogContent: ({ children }: any) => <div>{children}</div>,
+  DialogHeader: ({ children }: any) => <div>{children}</div>,
+  DialogTitle: ({ children }: any) => <div>{children}</div>,
+  DialogTrigger: ({ children }: any) => <div>{children}</div>,
+}));
+
+beforeEach(() => {
+  queryClient.clear();
+  toast.mockReset();
+  mutationMocks.length = 0;
+});
+
+describe('Payroll page', () => {
+  it('renders payroll runs and handles generate/delete with error handling', () => {
+    const payrollRuns = [
+      {
+        id: '1',
+        period: 'Jan 2024',
+        startDate: '2024-01-01',
+        endDate: '2024-01-31',
+        grossAmount: '1000',
+        netAmount: '800',
+        status: 'completed',
+      },
+    ];
+    queryClient.setQueryData(['/api/payroll'], payrollRuns);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Payroll />
+      </QueryClientProvider>
+    );
+
+    expect(screen.getByText('Jan 2024')).toBeInTheDocument();
+
+    // generate payroll success
+    mutationMocks[0].mutate({});
+    expect(toast).toHaveBeenCalledWith({ title: 'Success', description: 'Payroll generated successfully' });
+    toast.mockReset();
+    // generate payroll error
+    mutationMocks[0].shouldError = true;
+    mutationMocks[0].mutate({});
+    expect(toast).toHaveBeenCalledWith({ title: 'Error', description: 'Failed to generate payroll', variant: 'destructive' });
+    mutationMocks[0].shouldError = false;
+    toast.mockReset();
+
+    // delete payroll success
+    mutationMocks[1].mutate('1');
+    expect(toast).toHaveBeenCalledWith({ title: 'Success', description: 'Payroll run deleted successfully' });
+    toast.mockReset();
+    // delete payroll error
+    mutationMocks[1].shouldError = true;
+    mutationMocks[1].mutate('1');
+    expect(toast).toHaveBeenCalledWith({ title: 'Error', description: 'Failed to delete payroll run', variant: 'destructive' });
+  });
+});
+


### PR DESCRIPTION
## Summary
- cover loans page list and mutation flows with success and error toasts
- exercise cars page create/assign/update/delete paths
- validate payroll page generation and deletion scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a04874a0308323b8ab33b4bff10fa8