### PR TITLE
Enforce SESSION_SECRET requirement for production startup

### DIFF
--- a/HRPayMaster/README.md
+++ b/HRPayMaster/README.md
@@ -13,6 +13,10 @@
      SESSION_SECRET="<random session secret>"
      ```
 
+   > [!IMPORTANT]
+   > `SESSION_SECRET` must be set in production. The server will refuse to
+   > start without it to ensure session data remains secure.
+
 3. **Install dependencies**
 
    ```bash

--- a/HRPayMaster/server/index.ts
+++ b/HRPayMaster/server/index.ts
@@ -45,9 +45,19 @@ const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 
+const sessionSecret = process.env.SESSION_SECRET;
+if (!sessionSecret) {
+  const message = "SESSION_SECRET environment variable is required";
+  if (app.get("env") === "production") {
+    throw new Error(message);
+  } else {
+    log(`warning: ${message}; using default 'secret'`);
+  }
+}
+
 app.use(
   session({
-    secret: process.env.SESSION_SECRET || "secret",
+    secret: sessionSecret || "secret",
     resave: false,
     saveUninitialized: false,
     store: new MemoryStore({ checkPeriod: 86400000 }),


### PR DESCRIPTION
## Summary
- require `SESSION_SECRET` at server startup and fail if missing in production
- document `SESSION_SECRET` as mandatory for secure deployments

## Testing
- `npm test`
- `npm run check` *(fails: 'employees' is of type 'unknown')*

------
https://chatgpt.com/codex/tasks/task_e_68a04e0a2d488323b2bea974b9a3b064