### PR TITLE
Handle non-financial employee events

### DIFF
--- a/HRPayMaster/client/src/pages/assets.tsx
+++ b/HRPayMaster/client/src/pages/assets.tsx
@@ -16,7 +16,8 @@ import {
   insertAssetAssignmentSchema,
   type AssetWithAssignment,
   type AssetAssignmentWithDetails,
-  type InsertAssetAssignment
+  type InsertAssetAssignment,
+  type Employee
 } from "@shared/schema";
 
 export default function Assets() {
@@ -32,7 +33,7 @@ export default function Assets() {
     queryKey: ["/api/asset-assignments"],
   });
 
-  const { data: employees = [] } = useQuery({
+  const { data: employees = [] } = useQuery<Employee[]>({
     queryKey: ["/api/employees"],
   });
 
@@ -133,7 +134,7 @@ export default function Assets() {
                             </SelectTrigger>
                           </FormControl>
                           <SelectContent>
-                            {employees.map((emp: any) => (
+                            {employees.map((emp) => (
                               <SelectItem key={emp.id} value={emp.id}>
                                 {emp.firstName} {emp.lastName}
                               </SelectItem>

--- a/HRPayMaster/shared/schema.ts
+++ b/HRPayMaster/shared/schema.ts
@@ -217,10 +217,10 @@ export const emailAlerts = pgTable("email_alerts", {
 export const employeeEvents = pgTable("employee_events", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
   employeeId: varchar("employee_id").references(() => employees.id).notNull(),
-  eventType: text("event_type").notNull(), // bonus, deduction, allowance, overtime, penalty
+  eventType: text("event_type").notNull(), // bonus, deduction, allowance, overtime, penalty, employee_update, document_update, fleet_assignment, fleet_update, fleet_removal
   title: text("title").notNull(),
   description: text("description").notNull(),
-  amount: numeric("amount", { precision: 10, scale: 2 }).notNull(),
+  amount: numeric("amount", { precision: 10, scale: 2 }).notNull().default("0"),
   eventDate: date("event_date").notNull(),
   affectsPayroll: boolean("affects_payroll").default(true),
   documentUrl: text("document_url"), // For uploaded supporting documents
@@ -288,9 +288,25 @@ export const insertEmailAlertSchema = createInsertSchema(emailAlerts).omit({
   createdAt: true,
 });
 
-export const insertEmployeeEventSchema = createInsertSchema(employeeEvents).omit({
+const baseInsertEmployeeEventSchema = createInsertSchema(employeeEvents).omit({
   id: true,
   createdAt: true,
+});
+
+export const insertEmployeeEventSchema = baseInsertEmployeeEventSchema.extend({
+  eventType: z.enum([
+    "bonus",
+    "deduction",
+    "allowance",
+    "overtime",
+    "penalty",
+    "employee_update",
+    "document_update",
+    "fleet_assignment",
+    "fleet_update",
+    "fleet_removal",
+  ]),
+  amount: baseInsertEmployeeEventSchema.shape.amount.optional().default("0"),
 });
 
 export const insertSickLeaveTrackingSchema = createInsertSchema(sickLeaveTracking).omit({


### PR DESCRIPTION
## Summary
- extend employee event schema with non-payroll types like employee_update and fleet_assignment
- default employee event amount to 0 and restrict eventType through zod
- hide amount input for non-financial events and show neutral icons/colors in the UI

## Testing
- `npm --prefix HRPayMaster run check`
- `npm --prefix HRPayMaster test`


------
https://chatgpt.com/codex/tasks/task_e_68a05731cad88323a96c1808dd7d1619