### PR TITLE
feat: support vacation employee events

### DIFF
--- a/HRPayMaster/client/src/components/payroll/smart-vacation-form.tsx
+++ b/HRPayMaster/client/src/components/payroll/smart-vacation-form.tsx
@@ -94,11 +94,7 @@ export function SmartVacationForm({
 
     // Create event first, then update payroll
     try {
-      await fetch("/api/employee-events", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(eventData),
-      });
+      await apiRequest("POST", "/api/employee-events", eventData);
     } catch (error) {
       console.error("Failed to create employee event:", error);
     }

--- a/HRPayMaster/server/routes/payroll.ts
+++ b/HRPayMaster/server/routes/payroll.ts
@@ -118,7 +118,8 @@ payrollRouter.post("/generate", async (req, res, next) => {
         event.affectsPayroll &&
         event.status === "active" &&
         new Date(event.eventDate) >= periodStart &&
-        new Date(event.eventDate) <= periodEnd
+        new Date(event.eventDate) <= periodEnd &&
+        event.eventType !== "vacation"
       );
 
       const bonusAmount = employeeEventsInPeriod

--- a/HRPayMaster/shared/schema.ts
+++ b/HRPayMaster/shared/schema.ts
@@ -217,7 +217,7 @@ export const emailAlerts = pgTable("email_alerts", {
 export const employeeEvents = pgTable("employee_events", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
   employeeId: varchar("employee_id").references(() => employees.id).notNull(),
-  eventType: text("event_type").notNull(), // bonus, deduction, allowance, overtime, penalty, employee_update, document_update, fleet_assignment, fleet_update, fleet_removal
+  eventType: text("event_type").notNull(), // bonus, deduction, allowance, overtime, penalty, vacation, employee_update, document_update, fleet_assignment, fleet_update, fleet_removal
   title: text("title").notNull(),
   description: text("description").notNull(),
   amount: numeric("amount", { precision: 10, scale: 2 }).notNull().default("0"),
@@ -300,6 +300,7 @@ export const insertEmployeeEventSchema = baseInsertEmployeeEventSchema.extend({
     "allowance",
     "overtime",
     "penalty",
+    "vacation",
     "employee_update",
     "document_update",
     "fleet_assignment",


### PR DESCRIPTION
## Summary
- allow `vacation` as an employee event type in shared schema
- exclude vacation events from payroll calculations on server
- use `apiRequest` to submit vacation events from smart vacation form

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a05c94b0848323abf520cfec56ac4a