### PR TITLE
refactor: centralize api requests

### DIFF
--- a/HRPayMaster/client/src/components/payroll/enhanced-payroll-table.tsx
+++ b/HRPayMaster/client/src/components/payroll/enhanced-payroll-table.tsx
@@ -23,6 +23,7 @@ import { formatCurrency } from "@/lib/utils";
 import type { PayrollEntry } from "@shared/schema";
 import { SmartVacationForm } from "@/components/payroll/smart-vacation-form";
 import { SmartDeductionForm } from "@/components/payroll/smart-deduction-form";
+import { apiRequest } from "@/lib/queryClient";
 
 interface EnhancedPayrollTableProps {
   entries: any[];
@@ -46,13 +47,8 @@ export function EnhancedPayrollTable({ entries, payrollId }: EnhancedPayrollTabl
 
   const updatePayrollEntryMutation = useMutation({
     mutationFn: async ({ entryId, updates }: { entryId: string; updates: Partial<PayrollEntry> }) => {
-      const response = await fetch(`/api/payroll/entries/${entryId}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(updates),
-      });
-      if (!response.ok) throw new Error("Failed to update payroll entry");
-      return response.json();
+      const res = await apiRequest("PUT", `/api/payroll/entries/${entryId}`, updates);
+      return res.json();
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/payroll", payrollId] });

--- a/HRPayMaster/client/src/components/payroll/payroll-edit-view-simple.tsx
+++ b/HRPayMaster/client/src/components/payroll/payroll-edit-view-simple.tsx
@@ -22,6 +22,7 @@ import { SmartVacationForm } from "@/components/payroll/smart-vacation-form";
 import { SmartDeductionForm } from "@/components/payroll/smart-deduction-form";
 import { EnhancedPayrollTable } from "@/components/payroll/enhanced-payroll-table";
 import { SimpleExportModal } from "@/components/payroll/simple-export-modal";
+import { apiRequest } from "@/lib/queryClient";
 
 interface PayrollEditViewProps {
   payrollId: string;
@@ -45,13 +46,8 @@ export default function PayrollEditView({ payrollId }: PayrollEditViewProps) {
 
   const updatePayrollEntryMutation = useMutation({
     mutationFn: async ({ entryId, updates }: { entryId: string; updates: Partial<PayrollEntry> }) => {
-      const response = await fetch(`/api/payroll/entries/${entryId}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(updates),
-      });
-      if (!response.ok) throw new Error("Failed to update payroll entry");
-      return response.json();
+      const res = await apiRequest("PUT", `/api/payroll/entries/${entryId}`, updates);
+      return res.json();
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/payroll", payrollId] });

--- a/HRPayMaster/client/src/components/payroll/smart-deduction-form.tsx
+++ b/HRPayMaster/client/src/components/payroll/smart-deduction-form.tsx
@@ -108,13 +108,14 @@ export function SmartDeductionForm({
 
     // Create event first, then update payroll
     try {
-      await fetch("/api/employee-events", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(eventData),
-      });
-    } catch (error) {
+      await apiRequest("POST", "/api/employee-events", eventData);
+    } catch (error: any) {
       console.error("Failed to create employee event:", error);
+      toast({
+        title: "Error",
+        description: error.message || "Failed to create employee event",
+        variant: "destructive",
+      });
     }
 
     await updatePayrollMutation.mutateAsync(updateData);


### PR DESCRIPTION
## Summary
- replace direct fetch calls with shared apiRequest helper across employee and payroll components
- enhance apiRequest error reporting and integrate into query client
- standardize toast-based error handling for API interactions

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68a05e5d767c83238a9318ff3a59fff8