### PR TITLE
Add employee code to employees

### DIFF
--- a/HRPayMaster/client/src/components/employees/employee-form.tsx
+++ b/HRPayMaster/client/src/components/employees/employee-form.tsx
@@ -16,6 +16,7 @@ const formSchema = insertEmployeeSchema.extend({
   visaAlertDays: z.coerce.number().min(1).max(365).optional(),
   civilIdAlertDays: z.coerce.number().min(1).max(365).optional(),
   passportAlertDays: z.coerce.number().min(1).max(365).optional(),
+  employeeCode: z.string().min(1, "Employee code is required"),
 });
 
 type FormData = z.infer<typeof formSchema>;
@@ -38,6 +39,7 @@ export default function EmployeeForm({
     defaultValues: {
       firstName: initialData?.firstName || "",
       lastName: initialData?.lastName || "",
+      employeeCode: initialData?.employeeCode || "",
       email: initialData?.email || "",
       phone: initialData?.phone || "",
       position: initialData?.position || "",
@@ -67,6 +69,20 @@ export default function EmployeeForm({
     <Form {...form}>
       <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <FormField
+            control={form.control}
+            name="employeeCode"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Employee Code</FormLabel>
+                <FormControl>
+                  <Input placeholder="EMP001" disabled={!!initialData?.employeeCode} {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
           <FormField
             control={form.control}
             name="firstName"

--- a/HRPayMaster/client/src/pages/employees.test.tsx
+++ b/HRPayMaster/client/src/pages/employees.test.tsx
@@ -56,8 +56,26 @@ describe('Employees page', () => {
   it('filters employees based on search input', async () => {
     const user = userEvent.setup();
     const employees = [
-      { id: '1', firstName: 'Alice', lastName: 'Smith', position: 'Dev', salary: '0', workLocation: 'Office', startDate: '2024-01-01' },
-      { id: '2', firstName: 'Bob', lastName: 'Jones', position: 'Dev', salary: '0', workLocation: 'Office', startDate: '2024-01-01' },
+      {
+        id: '1',
+        employeeCode: 'E1',
+        firstName: 'Alice',
+        lastName: 'Smith',
+        position: 'Dev',
+        salary: '0',
+        workLocation: 'Office',
+        startDate: '2024-01-01',
+      },
+      {
+        id: '2',
+        employeeCode: 'E2',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        position: 'Dev',
+        salary: '0',
+        workLocation: 'Office',
+        startDate: '2024-01-01',
+      },
     ];
     queryClient.setQueryData(['/api/employees'], employees);
     queryClient.setQueryData(['/api/departments'], []);

--- a/HRPayMaster/client/src/pages/employees.tsx
+++ b/HRPayMaster/client/src/pages/employees.tsx
@@ -123,9 +123,10 @@ export default function Employees() {
 
   const handleUpdateEmployee = (employee: InsertEmployee) => {
     if (editingEmployee) {
+      const { employeeCode, ...updates } = employee;
       updateEmployeeMutation.mutate({
         id: editingEmployee.id,
-        employee,
+        employee: updates,
       });
     }
   };

--- a/HRPayMaster/migrations/0002_add_employee_code.sql
+++ b/HRPayMaster/migrations/0002_add_employee_code.sql
@@ -1,0 +1,4 @@
+ALTER TABLE employees ADD COLUMN IF NOT EXISTS employee_code varchar;
+UPDATE employees SET employee_code = id WHERE employee_code IS NULL;
+ALTER TABLE employees ALTER COLUMN employee_code SET NOT NULL;
+ALTER TABLE employees ADD CONSTRAINT employees_employee_code_unique UNIQUE (employee_code);

--- a/HRPayMaster/server/routes.test.ts
+++ b/HRPayMaster/server/routes.test.ts
@@ -46,7 +46,16 @@ describe('employee routes', () => {
 
   it('GET /api/employees returns employees list', async () => {
     const mockEmployees = [
-      { id: '1', firstName: 'John', lastName: 'Doe', position: 'Dev', salary: '0', workLocation: 'Office', startDate: '2024-01-01' },
+      {
+        id: '1',
+        employeeCode: 'E001',
+        firstName: 'John',
+        lastName: 'Doe',
+        position: 'Dev',
+        salary: '0',
+        workLocation: 'Office',
+        startDate: '2024-01-01',
+      },
     ];
     (storage.getEmployees as any).mockResolvedValue(mockEmployees);
 

--- a/HRPayMaster/server/routes.ts
+++ b/HRPayMaster/server/routes.ts
@@ -149,7 +149,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.put("/api/employees/:id", async (req, res, next) => {
     try {
-      const updates = insertEmployeeSchema.partial().parse(req.body);
+      const updates = insertEmployeeSchema
+        .omit({ employeeCode: true })
+        .partial()
+        .parse(req.body);
       const updatedEmployee = await storage.updateEmployee(req.params.id, updates);
       if (!updatedEmployee) {
         return next(new HttpError(404, "Employee not found"));

--- a/HRPayMaster/server/storage.ts
+++ b/HRPayMaster/server/storage.ts
@@ -72,7 +72,10 @@ export interface IStorage {
   getEmployees(): Promise<EmployeeWithDepartment[]>;
   getEmployee(id: string): Promise<EmployeeWithDepartment | undefined>;
   createEmployee(employee: InsertEmployee): Promise<Employee>;
-  updateEmployee(id: string, employee: Partial<InsertEmployee>): Promise<Employee | undefined>;
+  updateEmployee(
+    id: string,
+    employee: Partial<Omit<InsertEmployee, "employeeCode">>
+  ): Promise<Employee | undefined>;
   deleteEmployee(id: string): Promise<boolean>;
 
   // Payroll methods
@@ -234,10 +237,14 @@ export class DatabaseStorage implements IStorage {
     return newEmployee;
   }
 
-  async updateEmployee(id: string, employee: Partial<InsertEmployee>): Promise<Employee | undefined> {
+  async updateEmployee(
+    id: string,
+    employee: Partial<Omit<InsertEmployee, "employeeCode">>
+  ): Promise<Employee | undefined> {
+    const { employeeCode, ...rest } = employee as any;
     const [updated] = await db
       .update(employees)
-      .set(employee)
+      .set(rest)
       .where(eq(employees.id, id))
       .returning();
     return updated || undefined;

--- a/HRPayMaster/shared/schema.ts
+++ b/HRPayMaster/shared/schema.ts
@@ -11,6 +11,7 @@ export const departments = pgTable("departments", {
 
 export const employees = pgTable("employees", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  employeeCode: varchar("employee_code").notNull().unique(),
   firstName: text("first_name").notNull(),
   lastName: text("last_name").notNull(),
   nickname: text("nickname"),


### PR DESCRIPTION
## Summary
- add database migration and schema column for employee_code
- require employeeCode across server and client
- prevent employee code from being updated once created

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68a065441dd483239b79a735f8249e86