### PR TITLE
Prevent employee code updates

### DIFF
--- a/HRPayMaster/server/routes.test.ts
+++ b/HRPayMaster/server/routes.test.ts
@@ -10,6 +10,7 @@ vi.mock('./storage', () => {
       getEmployees: vi.fn(),
       createEmployee: vi.fn(),
       createEmployeesBulk: vi.fn(),
+      updateEmployee: vi.fn(),
       getPayrollRuns: vi.fn(),
       getLoans: vi.fn(),
       getCars: vi.fn(),
@@ -72,6 +73,14 @@ describe('employee routes', () => {
     const res = await request(app).post('/api/employees').send({});
     expect(res.status).toBe(400);
     expect(res.body.error.message).toBe('Invalid employee data');
+  });
+
+  it('PUT /api/employees/:id rejects employeeCode updates', async () => {
+    const res = await request(app)
+      .put('/api/employees/1')
+      .send({ employeeCode: 'NEW' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.message).toBe('Employee code cannot be updated');
   });
 
   it('POST /api/employees/import imports employees from excel', async () => {

--- a/HRPayMaster/server/routes.ts
+++ b/HRPayMaster/server/routes.ts
@@ -191,6 +191,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.put("/api/employees/:id", async (req, res, next) => {
     try {
+      if ("employeeCode" in req.body) {
+        return next(new HttpError(400, "Employee code cannot be updated"));
+      }
       const updates = insertEmployeeSchema
         .omit({ employeeCode: true })
         .partial()

--- a/HRPayMaster/server/storage.ts
+++ b/HRPayMaster/server/storage.ts
@@ -269,10 +269,12 @@ export class DatabaseStorage implements IStorage {
     id: string,
     employee: Partial<Omit<InsertEmployee, "employeeCode">>
   ): Promise<Employee | undefined> {
-    const { employeeCode, ...rest } = employee as any;
+    if ("employeeCode" in (employee as any)) {
+      delete (employee as any).employeeCode;
+    }
     const [updated] = await db
       .update(employees)
-      .set(rest)
+      .set(employee)
       .where(eq(employees.id, id))
       .returning();
     return updated || undefined;


### PR DESCRIPTION
## Summary
- block updates to employeeCode in employee update route
- ensure storage.updateEmployee strips employeeCode
- test: reject employeeCode changes with 400

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a06a75b8f48323b77da984d8b48809