### PR TITLE
feat: add employee import template download

### DIFF
--- a/HRPayMaster/README.md
+++ b/HRPayMaster/README.md
@@ -40,26 +40,26 @@
 
 ### Preparing the Excel file
 
-- Save the file in **.xlsx** format.
-- The **first row must contain column headers**.
-- Each subsequent row represents one employee.
-- Include at least the required columns:
+- Use the **Download Template** button in the import screen or GET `/api/employees/import/template` to obtain a starter workbook.
+- The template includes headers in English and Arabic for common fields. Required columns are:
   - `employeeCode`
   - `firstName`
   - `lastName`
   - `position`
   - `salary`
   - `startDate`
-- Additional columns can be mapped to existing fields or custom fields.
+- Save the file in **.xlsx** format. The **first row must contain column headers**, and each subsequent row represents one employee.
+- Additional columns from the template can be mapped to existing or custom fields.
 
 ### Using the mapping UI
 
 1. Go to **Employees → Import**.
-2. Select your Excel file and click **Next** to detect headers.
-3. For each detected column, use the dropdown to choose a system field or **Custom field**.
-4. When choosing **Custom field**, enter a name to create a new field.
-5. Ensure all required fields are mapped, then click **Import**.
-6. The UI shows how many rows succeeded or failed.
+2. Click **Download Template** and fill it with employee data.
+3. Select your completed Excel file and click **Next** to detect headers.
+4. For each detected column, use the dropdown to choose a system field or **Custom field**.
+5. When choosing **Custom field**, enter a name to create a new field.
+6. Ensure all required fields are mapped, then click **Import**.
+7. The UI shows how many rows succeeded or failed.
 
 ### Expected server responses
 

--- a/HRPayMaster/client/src/components/employees/employee-import.tsx
+++ b/HRPayMaster/client/src/components/employees/employee-import.tsx
@@ -53,6 +53,24 @@ export default function EmployeeImport() {
     }
   };
 
+  const downloadTemplate = async () => {
+    try {
+      const res = await fetch("/api/employees/import/template");
+      if (!res.ok) throw new Error("Failed to download");
+      const blob = await res.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "employee-import-template.xlsx";
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      window.URL.revokeObjectURL(url);
+    } catch {
+      toast({ title: "Error", description: "Failed to download template", variant: "destructive" });
+    }
+  };
+
   const handleSelectionChange = (header: string, value: string) => {
     setSelections(prev => ({ ...prev, [header]: value }));
     if (value !== "custom") {
@@ -109,6 +127,7 @@ export default function EmployeeImport() {
         <Button onClick={headers.length ? handleImport : detectHeaders} disabled={!file || isSubmitting}>
           {headers.length ? "Import" : "Next"}
         </Button>
+        <Button variant="outline" onClick={downloadTemplate}>Download Template</Button>
       </div>
 
       {headers.length > 0 && (

--- a/HRPayMaster/server/routes.test.ts
+++ b/HRPayMaster/server/routes.test.ts
@@ -72,6 +72,59 @@ describe('employee routes', () => {
     expect(res.body).toEqual(mockEmployees);
   });
 
+  it('GET /api/employees/import/template returns xlsx with headers', async () => {
+    const res = await request(app)
+      .get('/api/employees/import/template')
+      .buffer()
+      .parse((res, callback) => {
+        res.setEncoding('binary');
+        let data = '';
+        res.on('data', chunk => { data += chunk; });
+        res.on('end', () => { callback(null, Buffer.from(data, 'binary')); });
+      });
+
+    expect(res.status).toBe(200);
+    const wb = XLSX.read(res.body, { type: 'buffer' });
+    const sheet = wb.Sheets[wb.SheetNames[0]];
+    const headers = XLSX.utils.sheet_to_json(sheet, { header: 1 })[0];
+    expect(headers).toEqual([
+      'id/معرف',
+      'English Name/اسم الانجليزي',
+      'Image URL/رابط الصورة',
+      'Arabic Name/اسم المؤظف',
+      'Job Title/لقب',
+      'Work Location/مكان العمل',
+      'Nationality/الجنسية',
+      'Profession/المهنة',
+      'Employment Date/تاريخ التوظيف',
+      'Status/الحالة',
+      'Civil ID Number/رقم البطاقة المدنية',
+      'civil id issue date',
+      'Civil ID Expiry Date/تاريخ انتهاء البطاقة المدنية',
+      'Passport Number/رقم جواز السفر',
+      'Passport Issue Date/تاريخ اصدار جواز السفر',
+      'Passport Expiry Date/تاريخ انتهاء جواز السفر',
+      'Salaries/رواتب',
+      'loans',
+      'Transferable/تحويل',
+      'Payment Method/طريقة الدفع',
+      'Documents/مستندات or izenamal',
+      'Days Worked/أيام العمل',
+      'phonenumber',
+      'civil id pic',
+      'passport pic',
+      'driving license',
+      'driving license issue date',
+      'driving license expiry date',
+      'other docs',
+      'iban',
+      'SWIFTCODE',
+      'company',
+      'residency on company or not',
+      'profession department',
+    ]);
+  });
+
   it('POST /api/employees validates input data', async () => {
     const res = await request(app).post('/api/employees').send({});
     expect(res.status).toBe(400);

--- a/HRPayMaster/server/routes.ts
+++ b/HRPayMaster/server/routes.ts
@@ -124,6 +124,59 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.get("/api/employees/import/template", (_req, res) => {
+    const headers = [
+      "id/معرف",
+      "English Name/اسم الانجليزي",
+      "Image URL/رابط الصورة",
+      "Arabic Name/اسم المؤظف",
+      "Job Title/لقب",
+      "Work Location/مكان العمل",
+      "Nationality/الجنسية",
+      "Profession/المهنة",
+      "Employment Date/تاريخ التوظيف",
+      "Status/الحالة",
+      "Civil ID Number/رقم البطاقة المدنية",
+      "civil id issue date",
+      "Civil ID Expiry Date/تاريخ انتهاء البطاقة المدنية",
+      "Passport Number/رقم جواز السفر",
+      "Passport Issue Date/تاريخ اصدار جواز السفر",
+      "Passport Expiry Date/تاريخ انتهاء جواز السفر",
+      "Salaries/رواتب",
+      "loans",
+      "Transferable/تحويل",
+      "Payment Method/طريقة الدفع",
+      "Documents/مستندات or izenamal",
+      "Days Worked/أيام العمل",
+      "phonenumber",
+      "civil id pic",
+      "passport pic",
+      "driving license",
+      "driving license issue date",
+      "driving license expiry date",
+      "other docs",
+      "iban",
+      "SWIFTCODE",
+      "company",
+      "residency on company or not",
+      "profession department",
+    ];
+
+    const ws = XLSX.utils.aoa_to_sheet([headers]);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, "Employees");
+    const buffer = XLSX.write(wb, { bookType: "xlsx", type: "buffer" });
+    res.setHeader(
+      "Content-Type",
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    );
+    res.setHeader(
+      "Content-Disposition",
+      'attachment; filename="employee-import-template.xlsx"'
+    );
+    res.send(buffer);
+  });
+
   app.post("/api/employees/import", upload.single("file"), async (req, res, next) => {
     const file = (req as Request & { file?: Express.Multer.File }).file;
     if (!file) {


### PR DESCRIPTION
## Summary
- stream an employee import template from `/api/employees/import/template`
- add a "Download Template" button to employee import UI
- document the new workflow and required fields

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68a071b7c4208323b96debf189a8448c