### PR TITLE
Reset import form after successful employee import

### DIFF
--- a/HRPayMaster/client/src/components/employees/employee-import.tsx
+++ b/HRPayMaster/client/src/components/employees/employee-import.tsx
@@ -103,7 +103,6 @@ export default function EmployeeImport() {
     try {
       const res = await fetch("/api/employees/import", { method: "POST", body: formData });
       const data = await res.json();
-      setResult(data);
       if (res.ok) {
         queryClient.invalidateQueries({ queryKey: ["/api/employees"] });
         toast({
@@ -111,7 +110,14 @@ export default function EmployeeImport() {
           description: `${data.success || 0} imported, ${data.failed || 0} failed`,
           variant: data.failed ? "destructive" : "default",
         });
+        setFile(null);
+        setHeaders([]);
+        setSelections({});
+        setCustomFields({});
+        setResult(null);
+        window.scrollTo({ top: 0, behavior: "smooth" });
       } else {
+        setResult(data);
         toast({ title: "Error", description: data.error?.message || "Import failed", variant: "destructive" });
       }
     } catch {


### PR DESCRIPTION
## Summary
- Reset file and field selections after a successful employee import
- Scroll to top after import to indicate refreshed list

## Testing
- `npm run check` (fails: Cannot find name 'afterEach')
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0a1175fa48323a058c0fc0be71853